### PR TITLE
Remove TLS args when feature not enabled

### DIFF
--- a/kuksa_databroker/databroker-cli/src/main.rs
+++ b/kuksa_databroker/databroker-cli/src/main.rs
@@ -70,6 +70,7 @@ struct Cli {
     token_file: Option<String>,
 
     /// CA certificate used to verify server certificate
+    #[cfg(feature = "tls")]
     #[clap(long, value_name = "CERT", display_order = 3)]
     ca_cert: Option<String>,
 

--- a/kuksa_databroker/databroker/src/grpc/server.rs
+++ b/kuksa_databroker/databroker/src/grpc/server.rs
@@ -33,9 +33,9 @@ pub enum Authorization {
     Enabled { token_decoder: jwt::Decoder },
 }
 
+#[cfg(feature = "tls")]
 pub enum ServerTLS {
     Disabled,
-    #[cfg(feature = "tls")]
     Enabled { tls_config: ServerTlsConfig },
 }
 
@@ -97,7 +97,7 @@ where
 pub async fn serve<F>(
     addr: impl Into<std::net::SocketAddr>,
     broker: broker::DataBroker,
-    server_tls: ServerTLS,
+    #[cfg(feature = "tls")] server_tls: ServerTLS,
     authorization: Authorization,
     signal: F,
 ) -> Result<(), Box<dyn std::error::Error>>
@@ -112,8 +112,8 @@ where
         .http2_keepalive_interval(Some(Duration::from_secs(10)))
         .http2_keepalive_timeout(Some(Duration::from_secs(20)));
 
+    #[cfg(feature = "tls")]
     match server_tls {
-        #[cfg(feature = "tls")]
         ServerTLS::Enabled { tls_config } => {
             info!("Using TLS");
             builder = builder.tls_config(tls_config)?;

--- a/kuksa_databroker/databroker/src/main.rs
+++ b/kuksa_databroker/databroker/src/main.rs
@@ -16,11 +16,15 @@
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 use databroker::broker::RegistrationError;
-use databroker::grpc::server::{Authorization, ServerTLS};
-use tracing::{debug, error, info, warn};
+use databroker::grpc::server::Authorization;
+#[cfg(feature = "tls")]
+use databroker::grpc::server::ServerTLS;
 
 use tokio::select;
 use tokio::signal::unix::{signal, SignalKind};
+#[cfg(feature = "tls")]
+use tracing::warn;
+use tracing::{debug, error, info};
 
 use clap::{Arg, ArgAction, Command};
 
@@ -203,7 +207,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         option_env!("VERGEN_CARGO_DEBUG").unwrap_or(""),
     );
 
-    let parser = Command::new("Kuksa Data Broker")
+    let mut parser = Command::new("Kuksa Data Broker");
+    parser = parser
         .version(version)
         .about(about)
         .arg(
@@ -253,31 +258,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .required(false),
         )
         .arg(
-            Arg::new("insecure")
-                .display_order(6)
-                .long("insecure")
-                .help("Allow insecure connections")
-                .action(ArgAction::SetTrue),
-        )
-        .arg(
-            Arg::new("tls-cert")
-                .display_order(5)
-                .long("tls-cert")
-                .help("TLS certificate file (.pem)")
-                .action(ArgAction::Set)
-                .value_name("FILE")
-                .conflicts_with("insecure"),
-        )
-        .arg(
-            Arg::new("tls-private-key")
-                .display_order(5)
-                .long("tls-private-key")
-                .help("TLS private key file (.key)")
-                .action(ArgAction::Set)
-                .value_name("FILE")
-                .conflicts_with("insecure"),
-        )
-        .arg(
             Arg::new("dummy-metadata")
                 .display_order(10)
                 .long("dummy-metadata")
@@ -285,6 +265,37 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .help("Populate data broker with dummy metadata")
                 .required(false),
         );
+
+    #[cfg(feature = "tls")]
+    {
+        parser = parser
+            .arg(
+                Arg::new("insecure")
+                    .display_order(6)
+                    .long("insecure")
+                    .help("Allow insecure connections")
+                    .action(ArgAction::SetTrue),
+            )
+            .arg(
+                Arg::new("tls-cert")
+                    .display_order(5)
+                    .long("tls-cert")
+                    .help("TLS certificate file (.pem)")
+                    .action(ArgAction::Set)
+                    .value_name("FILE")
+                    .conflicts_with("insecure"),
+            )
+            .arg(
+                Arg::new("tls-private-key")
+                    .display_order(5)
+                    .long("tls-private-key")
+                    .help("TLS private key file (.key)")
+                    .action(ArgAction::Set)
+                    .value_name("FILE")
+                    .conflicts_with("insecure"),
+            );
+    }
+
     let args = parser.get_matches();
 
     // install global collector configured based on RUST_LOG env var.
@@ -353,47 +364,39 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
+    #[cfg(feature = "tls")]
     let tls_config = if args.get_flag("insecure") {
         ServerTLS::Disabled
     } else {
-        #[cfg(feature = "tls")]
-        {
-            let cert_file = args.get_one::<String>("tls-cert");
-            let key_file = args.get_one::<String>("tls-private-key");
-            match (cert_file, key_file) {
-                (Some(cert_file), Some(key_file)) => {
-                    let cert = std::fs::read(cert_file)?;
-                    let key = std::fs::read(key_file)?;
-                    let identity = tonic::transport::Identity::from_pem(cert, key);
-                    ServerTLS::Enabled {
-                        tls_config: tonic::transport::ServerTlsConfig::new().identity(identity),
-                    }
-                }
-                (Some(_), None) => {
-                    return Err(
-                        "TLS private key (--tls-private-key) must be set if --tls-cert is.".into(),
-                    );
-                }
-                (None, Some(_)) => {
-                    return Err(
-                        "TLS certificate (--tls-cert) must be set if --tls-private-key is.".into(),
-                    );
-                }
-                (None, None) => {
-                    warn!(
-                        "Default behavior of accepting insecure connections \
-                        when TLS is not configured may change in the future! \
-                        Please use --insecure to explicitly enable this behavior."
-                    );
-                    ServerTLS::Disabled
+        let cert_file = args.get_one::<String>("tls-cert");
+        let key_file = args.get_one::<String>("tls-private-key");
+        match (cert_file, key_file) {
+            (Some(cert_file), Some(key_file)) => {
+                let cert = std::fs::read(cert_file)?;
+                let key = std::fs::read(key_file)?;
+                let identity = tonic::transport::Identity::from_pem(cert, key);
+                ServerTLS::Enabled {
+                    tls_config: tonic::transport::ServerTlsConfig::new().identity(identity),
                 }
             }
-        }
-        #[cfg(not(feature = "tls"))]
-        {
-
-            warn!("TLS feature not enabled falling back to insecure mode");
-            ServerTLS::Disabled
+            (Some(_), None) => {
+                return Err(
+                    "TLS private key (--tls-private-key) must be set if --tls-cert is.".into(),
+                );
+            }
+            (None, Some(_)) => {
+                return Err(
+                    "TLS certificate (--tls-cert) must be set if --tls-private-key is.".into(),
+                );
+            }
+            (None, None) => {
+                warn!(
+                    "Default behavior of accepting insecure connections \
+                        when TLS is not configured may change in the future! \
+                        Please use --insecure to explicitly enable this behavior."
+                );
+                ServerTLS::Disabled
+            }
         }
     };
 
@@ -419,7 +422,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         None => Authorization::Disabled,
     };
 
-    grpc::server::serve(addr, broker, tls_config, authorization, shutdown_handler()).await?;
+    grpc::server::serve(
+        addr,
+        broker,
+        #[cfg(feature = "tls")]
+        tls_config,
+        authorization,
+        shutdown_handler(),
+    )
+    .await?;
 
     Ok(())
 }


### PR DESCRIPTION
Remove TLS arguments when `tls` is not enabled, as their presence is otherwise confusing.